### PR TITLE
useLocaleExpo returns the active primary locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "name": "gettext-universal",
   "type": "module",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "name": "gettext-universal",
   "type": "module",
-  "version": "1.0.24",
+  "version": "1.0.23",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/src/use-locale-expo.js
+++ b/src/use-locale-expo.js
@@ -24,11 +24,14 @@ import TranslateContext from "./translate-context.js"
  * via refs, so a settings picker that calls `setLocale` stays in effect
  * across re-renders.
  *
- * Returns the active primary locale string (or `undefined` when no
- * primary/device locale is known yet) so callers can pass it as a
- * `useEffect` dependency without reaching for `config.getLocale()`. For
- * the callable-translator pattern, keep using `useTranslate()` /
- * `useTranslateExpo()` — both hooks remain available.
+ * Returns the currently active locale string from `config.getLocale()`
+ * (or `undefined` when no locale has been set yet) so callers can pass
+ * it as a `useEffect` dependency. The hook's own `setTick` subscription
+ * to `onLocaleChange` makes the return value reactive — including
+ * imperative `config.setLocale(...)` calls from a settings picker that
+ * does not also push through `TranslateContext`. For the callable-
+ * translator pattern, keep using `useTranslate()` / `useTranslateExpo()`
+ * — both hooks remain available.
  *
  * @returns {string | undefined}
  */
@@ -95,5 +98,11 @@ export default function useLocaleExpo() {
     config.setFallbacks(deviceLocales)
   }, [deviceLocales])
 
-  return primaryLocale
+  // Read the authoritative locale from `config` (rather than returning the
+  // derived `primaryLocale`) so an imperative `config.setLocale("de")` from a
+  // settings picker — which emits `onLocaleChange` and re-renders this hook
+  // via `setTick` above — surfaces in the return value too. Returning
+  // `primaryLocale` would miss those overrides whenever the host app does not
+  // also push the new locale through `TranslateContext`.
+  return config.getLocale()
 }

--- a/src/use-locale-expo.js
+++ b/src/use-locale-expo.js
@@ -24,10 +24,13 @@ import TranslateContext from "./translate-context.js"
  * via refs, so a settings picker that calls `setLocale` stays in effect
  * across re-renders.
  *
- * Returns `void`. For the callable-translator pattern, keep using
- * `useTranslate()` / `useTranslateExpo()` — both hooks remain available.
+ * Returns the active primary locale string (or `undefined` when no
+ * primary/device locale is known yet) so callers can pass it as a
+ * `useEffect` dependency without reaching for `config.getLocale()`. For
+ * the callable-translator pattern, keep using `useTranslate()` /
+ * `useTranslateExpo()` — both hooks remain available.
  *
- * @returns {void}
+ * @returns {string | undefined}
  */
 export default function useLocaleExpo() {
   const localeContext = useContext(TranslateContext)
@@ -91,4 +94,6 @@ export default function useLocaleExpo() {
     lastWrittenFallbacksRef.current = deviceLocales
     config.setFallbacks(deviceLocales)
   }, [deviceLocales])
+
+  return primaryLocale
 }


### PR DESCRIPTION
## Summary
- Bumps to `1.0.24`.
- `useLocaleExpo()` now returns the resolved primary locale string (or `undefined`) so callers can use it as a `useEffect` dependency without reaching for `config.getLocale()`.
- Hook still subscribes the calling component to locale changes; the return value is strictly additive.

## Test plan
- [ ] Existing consumers that ignore the return value continue to work unchanged.
- [ ] In a consuming app, `const locale = useLocaleExpo()` reflects the active locale and triggers `useEffect` when `config.setLocale(...)` is called from a settings picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)